### PR TITLE
Twitter point geometry; centroid of place attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Build GeoMesa convert module (geomesa-convert-all). Then build gm-data:
 | [New York City Taxi](https://publish.illinois.edu/dbwork/open-data/) | `nyctaxi`<sup>1</sup> <br> `nyctaxi-single` | `nyctaxi` <br> `nyctaxi-drop` <br> `nyctaxi-single` |
 | [Open Street Map GPX](http://planet.osm.org/gps/) | `osm` | `osm` |
 | [T-Drive](http://research.microsoft.com/apps/pubs/?id=152883) | | `tdrive` | `tdrive` |
-| [Twitter](https://dev.twitter.com/overview/api/tweets) <sup>2</sup> | `twitter` | `twtitter` <br> `twitter-bbox` <sup>3</sup> |
+| [Twitter](https://dev.twitter.com/overview/api/tweets) <sup>2</sup> | `twitter` | `twtitter` <br> `twitter-place-centroid` <sup>3</sup> |
 
 
 1. NYC Taxi data includes two points: the pickup and dropoff. The `nyctaxi` feature type contains one point and an indicator of whether it is the pickup or dropoff. The `nyctaxi-single` feature has both geometries.
 1. Converter expects one tweet per line in the file.
-1. Converter `twitter` applies precise point geometry if available; `twitter-bbox` produces a polygon from the bounding box of the tweet's place attribute.
+1. Converter `twitter` applies precise point geometry if available; `twitter-place-centroid` extracts the centroid from the bounding box of the tweet's place attribute.
 
 ## GeoMesa Tools installation
 

--- a/gm-data-twitter/README.md
+++ b/gm-data-twitter/README.md
@@ -8,11 +8,11 @@ The converter expects data is in JSON that has had newlines removed, such that t
 
 Twitter data collected with location data may have a point location if the user posts with precise location. This is stored in the `coordinates` field. Otherwise the tweet is associated with a named place, which has a bounding box. 
 
-The bounding box provided by the Twitter API is not a properly formed geoJson polygon. The array of points does not form a linear ring, as it does not close. Thus the converter takes the bounds and builds a polygon from it.
+The bounding box provided by the Twitter API is not a properly formed geoJson polygon. The array of points does not form a linear ring, as it does not close. Thus the converter takes the bounds and builds a polygon from it. The centroid of this box is then taken as a point geometry for the tweet.
 
 ## Ingest procedure
 
 A recommended ingest procedure is to ingest first picking up the bounding boxes. Tweets with point geometry may fail this ingest. Then ingest to pick up the points. Tweets without points will fail this ingest, and their geometries will remain as set in the first pass.
 
-    geomesa ingest -u USERNAME -c CATALOG -s twitter -C twitter-bbox hdfs://namenode:port/path/to/twitter/*
+    geomesa ingest -u USERNAME -c CATALOG -s twitter -C twitter-place-centroid hdfs://namenode:port/path/to/twitter/*
     geomesa ingest -u USERNAME -c CATALOG -s twitter -C twitter hdfs://namenode:port/path/to/twitter/*

--- a/gm-data-twitter/src/main/resources/reference.conf
+++ b/gm-data-twitter/src/main/resources/reference.conf
@@ -19,7 +19,7 @@ geomesa  {
         { name = lang                 , type = String }
 
         { name = dtg                  , type = Date }
-        { name = geom                 , type = Geometry, srid = 4326 }
+        { name = geom                 , type = Point, srid = 4326 }
       ]
       user-data = {
         geomesa.table.sharing = "false"
@@ -51,7 +51,7 @@ geomesa  {
         { name = geom, json-type = "geometry", path = "$.coordinates" }
       ]
     }
-    twitter-bbox {
+    twitter-place-centroid {
       type = json
       id-field = "$tweet_id"
       fields = [
@@ -84,7 +84,8 @@ geomesa  {
         { name = bbwkt0, transform = "concatenate('polygon((', concatenate($sw, concatenate(', ', concatenate($se , concatenate(', ' , $ne)))))" }
         { name = bbwkt1, transform = "concatenate(', ', concatenate($nw, concatenate (', ', concatenate($sw, '))'))))" }
         { name = bb_wkt, transform = "concatenate($bbwkt0, $bbwkt1)" }
-        { name = geom, transform = "polygon($bb_wkt)" }
+
+        { name = geom, transform = "cql:centroid(polygon($bb_wkt))" }
       ]
     }
   }


### PR DESCRIPTION
Update twitter to use `Point` geometry, instead of `Geometry`.
Use centroid of bounding box instead of actual bounding box.

